### PR TITLE
Rate-Limit and Queue-Tweaks

### DIFF
--- a/app/Console/Commands/QueueHealthChecks.php
+++ b/app/Console/Commands/QueueHealthChecks.php
@@ -48,7 +48,7 @@ class QueueHealthChecks extends Command
                     $this->totalPushed += $chunk->count();
 
                     // Push each site check to queue
-                    $chunk->each(fn ($site) => CheckSiteHealth::dispatch($site)->onQueue('cron'));
+                    $chunk->each(fn ($site) => CheckSiteHealth::dispatch($site));
                 }
             );
 

--- a/app/Console/Commands/QueueHealthChecks.php
+++ b/app/Console/Commands/QueueHealthChecks.php
@@ -48,7 +48,7 @@ class QueueHealthChecks extends Command
                     $this->totalPushed += $chunk->count();
 
                     // Push each site check to queue
-                    $chunk->each(fn ($site) => CheckSiteHealth::dispatch($site));
+                    $chunk->each(fn ($site) => CheckSiteHealth::dispatch($site)->onQueue('cron'));
                 }
             );
 

--- a/app/Console/Commands/QueueUpdates.php
+++ b/app/Console/Commands/QueueUpdates.php
@@ -63,7 +63,7 @@ class QueueUpdates extends Command
                 $this->totalPushed += $chunk->count();
 
                 // Push each site check to queue
-                $chunk->each(fn ($site) => UpdateSite::dispatch($site, $targetVersion));
+                $chunk->each(fn ($site) => UpdateSite::dispatch($site, $targetVersion)->onQueue('updates'));
             }
         );
 

--- a/app/Jobs/CheckSiteHealth.php
+++ b/app/Jobs/CheckSiteHealth.php
@@ -31,7 +31,7 @@ class CheckSiteHealth implements ShouldQueue, ShouldBeUnique
      */
     public function uniqueId(): string
     {
-        return $this->site->id;
+        return (string) $this->site->id;
     }
 
     /**

--- a/app/Jobs/CheckSiteHealth.php
+++ b/app/Jobs/CheckSiteHealth.php
@@ -8,19 +8,30 @@ use App\Models\Site;
 use App\RemoteSite\Connection;
 use App\TUF\TufFetcher;
 use Carbon\Carbon;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\App;
 
-class CheckSiteHealth implements ShouldQueue
+class CheckSiteHealth implements ShouldQueue, ShouldBeUnique
 {
     use Queueable;
+
+    public int $uniqueFor = 120;
 
     /**
      * Create a new job instance.
      */
     public function __construct(protected readonly Site $site)
     {
+    }
+
+    /**
+     * Get the unique ID for the job.
+     */
+    public function uniqueId(): string
+    {
+        return $this->site->id;
     }
 
     /**
@@ -66,6 +77,6 @@ class CheckSiteHealth implements ShouldQueue
         UpdateSite::dispatch(
             $this->site,
             $latestVersion
-        );
+        )->onQueue('updates');
     }
 }

--- a/app/Jobs/UpdateSite.php
+++ b/app/Jobs/UpdateSite.php
@@ -9,21 +9,31 @@ use App\Models\Site;
 use App\RemoteSite\Connection;
 use App\RemoteSite\Responses\PrepareUpdate;
 use GuzzleHttp\Exception\RequestException;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Log;
 
-class UpdateSite implements ShouldQueue
+class UpdateSite implements ShouldQueue, ShouldBeUnique
 {
     use Queueable;
     protected ?int $preUpdateCode = null;
+    public int $uniqueFor = 3600;
 
     /**
      * Create a new job instance.
      */
     public function __construct(protected readonly Site $site, protected string $targetVersion)
     {
+    }
+
+    /**
+     * Get the unique ID for the job.
+     */
+    public function uniqueId(): string
+    {
+        return $this->site->id;
     }
 
     /**

--- a/app/Jobs/UpdateSite.php
+++ b/app/Jobs/UpdateSite.php
@@ -33,7 +33,7 @@ class UpdateSite implements ShouldQueue, ShouldBeUnique
      */
     public function uniqueId(): string
     {
-        return $this->site->id;
+        return (string) $this->site->id;
     }
 
     /**
@@ -146,7 +146,7 @@ class UpdateSite implements ShouldQueue, ShouldBeUnique
         $connection->notificationSuccess(["fromVersion" => $healthResult->cms_version]);
 
         // Trigger site health check to write the update version back to the db
-        CheckSiteHealth::dispatch($this->site);
+        CheckSiteHealth::dispatch($this->site)
     }
 
     protected function performExtraction(PrepareUpdate $prepareResult): void

--- a/app/Jobs/UpdateSite.php
+++ b/app/Jobs/UpdateSite.php
@@ -146,7 +146,7 @@ class UpdateSite implements ShouldQueue, ShouldBeUnique
         $connection->notificationSuccess(["fromVersion" => $healthResult->cms_version]);
 
         // Trigger site health check to write the update version back to the db
-        CheckSiteHealth::dispatch($this->site)
+        CheckSiteHealth::dispatch($this->site);
     }
 
     protected function performExtraction(PrepareUpdate $prepareResult): void

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -34,7 +34,7 @@ class AppServiceProvider extends ServiceProvider
             $siteIpLimits = [];
 
             if ($siteHost !== 'default') {
-                $siteIps = (new DNSLookup)->getIPs($siteHost);
+                $siteIps = (new DNSLookup())->getIPs($siteHost);
 
                 foreach ($siteIps as $siteIp) {
                     $siteIpLimits[] = Limit::perMinute(5)->by("siteip-" . $siteIp);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -27,7 +27,7 @@ class AppServiceProvider extends ServiceProvider
             $siteHost = 'default';
 
             if (is_string($request->input('url'))) {
-                $siteHost = parse_url($request->input('url'), PHP_URL_HOST);
+                $siteHost = (string) parse_url($request->input('url'), PHP_URL_HOST);
             }
 
             // Define a rate limit per target IP

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -30,7 +30,7 @@ class AppServiceProvider extends ServiceProvider
                 $siteHost = parse_url($request->input('url'), PHP_URL_HOST);
             }
 
-            if ($siteHost !== 'default' && $dnsResult = dns_get_record($siteHost, DNS_A)) {
+            if ($siteHost !== 'default' && $dnsResult = dns_get_record((string) $siteHost, DNS_A)) {
                 $siteIp = $dnsResult[0]['ip'];
             }
 

--- a/app/Providers/HttpclientServiceProvider.php
+++ b/app/Providers/HttpclientServiceProvider.php
@@ -21,42 +21,7 @@ class HttpclientServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton(Client::class, function ($app) {
-            $handlerStack = HandlerStack::create(new CurlHandler());
-            $handlerStack->push(
-                Middleware::retry(
-                    function (
-                        $retries,
-                        Request $request,
-                        Response $response = null,
-                        \Throwable $exception = null
-                    ) {
-                        // Limit the number of retries to 3
-                        if ($retries >= 3) {
-                            return false;
-                        }
-
-                        // Retry connection exceptions
-                        if ($exception instanceof ConnectException) {
-                            return true;
-                        }
-
-                        if ($response) {
-                            // Retry on server errors
-                            if ($response->getStatusCode() >= 500) {
-                                return true;
-                            }
-                        }
-
-                        return false;
-                    },
-                    function ($numberOfRetries) {
-                        return 1000 * $numberOfRetries;
-                    }
-                )
-            );
-
             return new Client([
-                'handler'  => $handlerStack,
                 'allow_redirects' => [
                     'max'             => 5,
                     'strict'          => true,  // "strict" redirects - that's key as a redirected POST stays a POST

--- a/app/Providers/HttpclientServiceProvider.php
+++ b/app/Providers/HttpclientServiceProvider.php
@@ -3,12 +3,6 @@
 namespace App\Providers;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Handler\CurlHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\ServiceProvider;
 
 class HttpclientServiceProvider extends ServiceProvider

--- a/app/RemoteSite/Connection.php
+++ b/app/RemoteSite/Connection.php
@@ -94,7 +94,9 @@ class Connection
                 "headers" => [
                     "Content-Type" => "application/json",
                     "Accept" => "application/vnd.api+json"
-                ]
+                ],
+                'timeout' => 60.0,
+                'connect_timeout' => 5.0,
             ]
         );
 

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -180,9 +180,9 @@ return [
     */
 
     'defaults' => [
-        'supervisor-cron'  => [
+        'supervisor-default'  => [
             'connection' => 'redis',
-            'queue' => ['default', 'cron'],
+            'queue' => ['default'],
             'balance' => 'auto',
             'autoScalingStrategy' => 'time',
             'maxProcesses' => 1,

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -180,9 +180,9 @@ return [
     */
 
     'defaults' => [
-        'supervisor-1' => [
+        'supervisor-cron'  => [
             'connection' => 'redis',
-            'queue' => ['default'],
+            'queue' => ['default', 'cron'],
             'balance' => 'auto',
             'autoScalingStrategy' => 'time',
             'maxProcesses' => 1,
@@ -190,22 +190,43 @@ return [
             'maxJobs' => 0,
             'memory' => 128,
             'tries' => 1,
-            'timeout' => 60,
+            'timeout' => 15,
+            'nice' => 0,
+        ],
+        'supervisor-updates' => [
+            'connection' => 'redis',
+            'queue' => ['updates'],
+            'balance' => 'auto',
+            'autoScalingStrategy' => 'time',
+            'maxProcesses' => 1,
+            'maxTime' => 0,
+            'maxJobs' => 0,
+            'memory' => 128,
+            'tries' => 1,
+            'timeout' => 600,
             'nice' => 0,
         ],
     ],
 
     'environments' => [
         'production' => [
-            'supervisor-1' => [
-                'maxProcesses' => 10,
-                'balanceMaxShift' => 1,
-                'balanceCooldown' => 3,
+            'supervisor-cron' => [
+                'maxProcesses' => 250,
+                'balanceMaxShift' => 10,
+                'balanceCooldown' => 25,
+            ],
+            'supervisor-updates' => [
+                'maxProcesses' => 500,
+                'balanceMaxShift' => 10,
+                'balanceCooldown' => 25,
             ],
         ],
 
         'local' => [
-            'supervisor-1' => [
+            'supervisor-cron' => [
+                'maxProcesses' => 3,
+            ],
+            'supervisor-updates' => [
                 'maxProcesses' => 3,
             ],
         ],

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -210,7 +210,7 @@ return [
 
     'environments' => [
         'production' => [
-            'supervisor-cron' => [
+            'supervisor-default' => [
                 'maxProcesses' => 250,
                 'balanceMaxShift' => 10,
                 'balanceCooldown' => 25,
@@ -223,7 +223,7 @@ return [
         ],
 
         'local' => [
-            'supervisor-cron' => [
+            'supervisor-default' => [
                 'maxProcesses' => 3,
             ],
             'supervisor-updates' => [


### PR DESCRIPTION
This PR applies various improvements to the current setup:
* we now have two queues: the default queue has a 15 second timeout and is used for health check jobs; the updates queue has has 10min timeout
* both jobs types now implement the "unique" interface, making sure only one job instance per site is executed at the same time
* the http client uses sensible values for connect and execution timeouts to prevent slow tasks from locking up update server resources
* the rate limiting now takes various factors (site host, site ip, request ip) into account