### PR TITLE
Fix comparsion logic

### DIFF
--- a/app/Console/Commands/QueueHealthChecks.php
+++ b/app/Console/Commands/QueueHealthChecks.php
@@ -34,7 +34,7 @@ class QueueHealthChecks extends Command
         $this->output->writeln('Pushing pending health checks');
 
         Site::query()
-            ->whereDate(
+            ->where(
                 'last_seen',
                 '<',
                 Carbon::now()->subHours((int) config('autoupdates.healthcheck_interval')) // @phpstan-ignore-line


### PR DESCRIPTION
### Summary of Changes
The health check did run once a day but only every two days because we were comparing date and not timestamps.
